### PR TITLE
Scroll improvements

### DIFF
--- a/Sources/SimpleTable/OnChangeModifier.swift
+++ b/Sources/SimpleTable/OnChangeModifier.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct OnChangeModifier<T: Equatable>: ViewModifier {
+  init(of value: T, perform action: @escaping (T, T) -> Void) {
+    self.value = value
+    self.action = action
+    self._oldValue = .init(wrappedValue: value)
+  }
+
+  var value: T
+  var action: (T, T) -> Void
+  @State var oldValue: T
+
+  func body(content: Content) -> some View {
+    content.onChange(of: value) { newValue in
+      action(oldValue, newValue)
+      oldValue = newValue
+    }
+  }
+}
+
+extension View {
+  func onChange<T: Equatable>(
+    of value: T,
+    perform action: @escaping (T, T) -> Void
+  ) -> some View {
+    modifier(OnChangeModifier(of: value, perform: action))
+  }
+}

--- a/Sources/SimpleTable/SimpleTableView.swift
+++ b/Sources/SimpleTable/SimpleTableView.swift
@@ -45,11 +45,6 @@ public struct SimpleTableView<Content>: View where Content: View {
     case .automatic:
       ViewThatFits(in: scrollAxes) {
         content()
-          .frame(
-            maxWidth: .infinity,
-            maxHeight: .infinity,
-            alignment: alignment
-          )
 
         scrollView {
           content()

--- a/Sources/SimpleTable/SimpleTableView.swift
+++ b/Sources/SimpleTable/SimpleTableView.swift
@@ -16,26 +16,22 @@ public struct SimpleTableView<Content>: View where Content: View {
   ///   - scrollMode: Scroll view mode. Defaults to `.automatic`.
   ///   - scrollAxes: Scrolling axes. Defaults to `.vertical` & `.horizontal`.
   ///   - showsScrollIndicators: Determines if scroll indicators should be visible. Defaults to `true`.
-  ///   - alignment: Table content alignment. Defaults to `.topLeading`.
   ///   - content: Table content. Use `SimpleTableLayout` to arrange views in table.
   public init(
     scrollMode: ScrollMode = .automatic,
     scrollAxes: Axis.Set = [.vertical, .horizontal],
     showsScrollIndicators: Bool = true,
-    alignment: Alignment = .topLeading,
     @ViewBuilder content: @escaping () -> Content
   ) {
     self.scrollMode = scrollMode
     self.scrollAxes = scrollAxes
     self.showsScrollIndicators = showsScrollIndicators
-    self.alignment = alignment
     self.content = content
   }
 
   public var scrollAxes: Axis.Set
   public var scrollMode: ScrollMode
   public var showsScrollIndicators: Bool
-  public var alignment: Alignment
   public var content: () -> Content
   @State var scrollViewSize: CGSize = .zero
   let startAnchorId = "simple-table-start-anchor-id"
@@ -63,7 +59,7 @@ public struct SimpleTableView<Content>: View where Content: View {
     @ViewBuilder content: @escaping () -> Content
   ) -> some View {
     ScrollViewReader { scrollViewProxy in
-      ZStack(alignment: alignment) {
+      ZStack {
         GeometryReader { geometryProxy in
           Color.clear
             .onAppear { scrollViewSize = geometryProxy.size }
@@ -79,9 +75,9 @@ public struct SimpleTableView<Content>: View where Content: View {
             .frame(
               minWidth: scrollViewSize.width,
               minHeight: scrollViewSize.height,
-              alignment: alignment
+              alignment: .topLeading
             )
-            .overlay(alignment: alignment) {
+            .overlay(alignment: .topLeading) {
               Color.clear.frame(width: 10, height: 10)
                 .allowsHitTesting(false)
                 .id(startAnchorId)


### PR DESCRIPTION
- [x] Remove `alignment` parameter from `SimpleTableView` (always align to the top leading point).
- [x] Improve scroll position handling when table content changes:
  - **WHEN** is scrolled to top leading point
  - **AND** content size changes
  - **AND** is no longer scrolled to top leading point
  - **THEN** scroll to top leading point